### PR TITLE
Fix to error: "update to newer phpstan is blocked"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0",
-        "phpstan/phpstan": "^0.12.68",
+        "phpstan/phpstan": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.2"
     },
     "autoload": {


### PR DESCRIPTION
Fix to error: "update to newer phpstan is blocked"
Below example output of a bug:
"bash-5.1$ composer require --dev "phpstan/phpstan-phpunit:^1.0.0" Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9011 (through xdebug.client_host/xdebug.client_port). ./composer.json has been updated
Running composer update phpstan/phpstan-phpunit
Loading composer repositories with package information Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - phpstan/phpstan-phpunit[1.1.x-dev, ..., 1.4.x-dev] require phpstan/phpstan ^1.11 -> found phpstan/phpstan[1.11.x-dev] but the package is fixed to 0.12.100 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - phpstan/phpstan-phpunit 1.0.0 requires phpstan/phpstan ^1.0 -> found phpstan/phpstan[1.0.0, ..., 1.11.x-dev] but the package is fixed to 0.12.100 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command. - phpstan/phpstan-phpunit[1.1.0, ..., 1.1.1] require phpstan/phpstan ^1.5.0 -> found phpstan/phpstan[1.5.0, ..., 1.11.x-dev] but the package is fixed to 0.12.100 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command. - phpstan/phpstan-phpunit[1.1.2, ..., 1.1.3] require phpstan/phpstan ^1.8.0 -> found phpstan/phpstan[1.8.0, ..., 1.11.x-dev] but the package is fixed to 0.12.100 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command. - phpstan/phpstan-phpunit[1.2.1, ..., 1.2.2] require phpstan/phpstan ^1.8.11 -> found phpstan/phpstan[1.8.11, ..., 1.11.x-dev] but the package is fixed to 0.12.100 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command. - phpstan/phpstan-phpunit[1.2.0, ..., 1.3.0] require phpstan/phpstan ^1.9.0 -> found phpstan/phpstan[1.9.0, ..., 1.11.x-dev] but the package is fixed to 0.12.100 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command. - phpstan/phpstan-phpunit[1.3.1, ..., 1.3.4] require phpstan/phpstan ^1.9.3 -> found phpstan/phpstan[1.9.3, ..., 1.11.x-dev] but the package is fixed to 0.12.100 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command. - phpstan/phpstan-phpunit[1.3.5, ..., 1.3.x-dev] require phpstan/phpstan ^1.10 -> found phpstan/phpstan[1.10.0, ..., 1.11.x-dev] but the package is fixed to 0.12.100 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command. - Root composer.json requires phpstan/phpstan-phpunit ^1.0.0 -> satisfiable by phpstan/phpstan-phpunit[1.0.0, ..., 1.4.x-dev]." "